### PR TITLE
URL import stuck as hash tiddler

### DIFF
--- a/weird-urls.txt
+++ b/weird-urls.txt
@@ -1,1 +1,2 @@
 https://primecables.ca/
+http://3dupndown.com/content/?page=&pcode=cont_view_new&mtype=au&idx=9579&chargeType=


### PR DESCRIPTION
This URL never becomes the final tiddler with the details, it is left as
the import tiddler named after the hash. This could be due to the site
using Cloudflare and requiring a capthca be filled out.

```
λ cat Link_\ 9e04f0fb60a089789b72aa7d71ec85ba1a8b613e.tid
created: 20210912130154216
location: http://3dupndown.com/content/?page=&pcode=cont_view_new&mtype=au&idx=9579&chargeType=
modified: 20210912130154217
title: Link: 9e04f0fb60a089789b72aa7d71ec85ba1a8b613e
type: text/vnd.tiddlywiki
url_tiddler: true
url_tiddler_pending_fetch: true
```