### PR TITLE
golang.cafe extraneous ] in title

### DIFF
--- a/weird-urls.txt
+++ b/weird-urls.txt
@@ -1,1 +1,2 @@
 https://primecables.ca/
+https://golang.cafe/blog/golang-debugging-with-delve.html


### PR DESCRIPTION
The title of the url inclused [Step by Step] but on import only the
final ] is included, but it's not included in the resulting $:/Import
tiddler, but is in the final title of the tiddler:

Golang Debugging with Delve - Step by Step]